### PR TITLE
Removed extraneous division that was "double scaling" images

### DIFF
--- a/Switch/Switch.m
+++ b/Switch/Switch.m
@@ -23,7 +23,6 @@
  */
 
 #import "Switch.h"
-#define Scale [UIScreen mainScreen].scale
 
 @interface Switch()
 {
@@ -50,7 +49,7 @@
         _origin = CGPointZero;
         
         self.frame = CGRectMake(_origin.x, _origin.y,
-                                _visibleWidth, _image.size.height/Scale);
+                                _visibleWidth, _image.size.height);
         self.clipsToBounds = YES;
         
         imgVw = [[UIImageView alloc] initWithFrame:CGRectZero];
@@ -81,8 +80,8 @@
     _visibleWidth = visibleWidth;
     
     self.frame = CGRectMake(_origin.x, _origin.y, _visibleWidth, self.frame.size.height);
-    imgVw.frame = CGRectMake((_on ? 0 : -(_image.size.width/Scale - _visibleWidth)), 0,
-                             _image.size.width/Scale, _image.size.height/Scale);
+    imgVw.frame = CGRectMake((_on ? 0 : -(_image.size.width - _visibleWidth)), 0,
+                             _image.size.width, _image.size.height);
 }
 
 -(void)setOrigin:(CGPoint)origin
@@ -96,9 +95,9 @@
 {
     _image = image;
     
-    self.frame = CGRectMake(_origin.x, _origin.y, _visibleWidth, _image.size.height/Scale);
-    imgVw.frame = CGRectMake((_on ? 0 : -(_image.size.width/Scale - _visibleWidth)), 0,
-                             _image.size.width/Scale, _image.size.height/Scale);
+    self.frame = CGRectMake(_origin.x, _origin.y, _visibleWidth, _image.size.height);
+    imgVw.frame = CGRectMake((_on ? 0 : -(_image.size.width - _visibleWidth)), 0,
+                             _image.size.width, _image.size.height);
     imgVw.image = _image;
 }
 


### PR DESCRIPTION
Out of the box my images were too small, and once I removed these divisions by scale the images were sized appropriately. 
